### PR TITLE
Add default_volume option to the config file.

### DIFF
--- a/process.py
+++ b/process.py
@@ -204,3 +204,8 @@ def setVolume(vol):
         volume += 300
     if vol == "less":
         volume -= 300
+
+
+def initVolume(vol):
+    global volume
+    volume = vol

--- a/raspberrycast.conf
+++ b/raspberrycast.conf
@@ -4,5 +4,6 @@
 "pi_hostname": "raspberrypi",
 "width": "",
 "height": "",
-"subtitle_search": false
+"subtitle_search": false,
+"default_volume": 0
 }

--- a/server.py
+++ b/server.py
@@ -13,7 +13,7 @@ except ImportError:
 from bottle import Bottle, SimpleTemplate, request, response, \
                    template, run, static_file
 from process import launchvideo, queuevideo, playlist, \
-                    setState, getState, setVolume
+                    setState, getState, setVolume, initVolume
 
 if len(sys.argv) > 1:
     config_file = sys.argv[1]
@@ -52,6 +52,7 @@ if config["new_log"]:
     os.system("sudo fbi -T 1 --noverbose -a  images/ready.jpg")
 
 setState("0")
+initVolume(config["default_volume"])
 open('video.queue', 'w').close()  # Reset queue
 logger.info('Server successfully started!')
 


### PR DESCRIPTION
It was bothering for me to have to reduce/increase the volume of my receiver when switching inputs, this allows the user to define a default volume in the configuration file.